### PR TITLE
Set write mode on sftp file uploads

### DIFF
--- a/lib/airlift/connection/sftp.rb
+++ b/lib/airlift/connection/sftp.rb
@@ -44,7 +44,7 @@ module Airlift
 
       # (see Base#upload_file)
       def upload_file(path, &block)
-        handle = sftp_connection.open!(path)
+        handle = sftp_connection.open!(path, 'w')
         offset = 0
         writer_proc = Proc.new do |data|
           sftp_connection.write!(handle, offset, data)


### PR DESCRIPTION
Currently the `open!` call on the remote system will return a `Net::SFTP::StatusException` because it tries to open in read mode and the file doesn't exist. This patch should fix the issue.
